### PR TITLE
Implement ButtBot vision stack skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# ButtBot Vision Stack
+
+## Quick Start
+1. `./env_setup.sh`
+2. `python calib/capture_checker.py`
+3. `python calib/homography.py`
+4. `python src/butt_detector.py`    # producer
+5. `python src/arm_listener.py`     # consumer
+
+## Performance Tips
+- Use a Jetson Nano or GPU device for best inference speed.
+- If frame rate falls below 10 FPS, the detector automatically switches to a smaller image size.
+
+## Common Errors
+- *Camera not found*: check `/dev/video0` exists or adjust the device index.
+- *ZeroMQ bind failure*: ensure no other process is using the specified port.
+- *Serial connection errors*: update `SERIAL_PORT` in `src/arm_listener.py`.
+
+## Tuning Parameters
+- Detection thresholds are defined in `src/butt_detector.py`.
+- Blob detection HSV ranges live in `src/fallback_blob.py`.
+- Arm movement heights such as `HOVER_Z` are set at the top of `src/arm_listener.py`.

--- a/calib/capture_checker.py
+++ b/calib/capture_checker.py
@@ -1,0 +1,35 @@
+"""Capture checkerboard image for homography calibration.
+
+Usage: python capture_checker.py
+Press SPACE to capture and save checker_raw.jpg.
+Press ESC to quit without saving.
+"""
+
+import cv2
+
+
+def main() -> None:
+    """Open camera and capture checkerboard image."""
+    cap = cv2.VideoCapture(0)
+    if not cap.isOpened():
+        raise RuntimeError("Could not open /dev/video0")
+
+    try:
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                continue
+            cv2.imshow("Checker Capture", frame)
+            key = cv2.waitKey(1) & 0xFF
+            if key == 27:  # ESC
+                break
+            if key == 32:  # SPACE
+                cv2.imwrite("calib/checker_raw.jpg", frame)
+                break
+    finally:
+        cap.release()
+        cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()

--- a/calib/homography.py
+++ b/calib/homography.py
@@ -1,0 +1,65 @@
+"""Compute homography matrix from captured checkerboard image.
+
+Usage: python homography.py
+Click four outer corners of the checkerboard starting at origin.
+Matrix is saved as homography.npy.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+
+IMG_PATH = Path("calib/checker_raw.jpg")
+
+
+points: List[Tuple[int, int]] = []
+
+def on_mouse(event: int, x: int, y: int, flags: int, param) -> None:
+    if event == cv2.EVENT_LBUTTONDOWN:
+        points.append((x, y))
+        print(f"Point {len(points)}: {(x, y)}")
+
+
+def main() -> None:
+    if not IMG_PATH.exists():
+        raise FileNotFoundError(str(IMG_PATH))
+
+    img = cv2.imread(str(IMG_PATH))
+    if img is None:
+        raise RuntimeError("Failed to load image")
+
+    cv2.namedWindow("Select Corners")
+    cv2.setMouseCallback("Select Corners", on_mouse)
+
+    while True:
+        disp = img.copy()
+        for p in points:
+            cv2.circle(disp, p, 5, (0, 255, 0), -1)
+        cv2.imshow("Select Corners", disp)
+        if cv2.waitKey(1) & 0xFF == 27 or len(points) >= 4:
+            break
+
+    cv2.destroyAllWindows()
+    if len(points) != 4:
+        print("Need exactly four points")
+        sys.exit(1)
+
+    src = np.array(points, dtype=np.float32)
+    dst = np.array([(0, 0), (200, 0), (200, 200), (0, 200)], dtype=np.float32)
+
+    H, _ = cv2.findHomography(src, dst)
+    if H is None:
+        raise RuntimeError("Homography computation failed")
+
+    np.save("calib/homography.npy", H)
+    print("Homography matrix:\n", H)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/env_setup.sh
+++ b/env_setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+python3 -m venv buttbot-env \
+  && source buttbot-env/bin/activate \
+  && pip install -U pip wheel \
+  && pip install "ultralytics==8.3.1" "fastsam==1.0.3" \
+                 pyzmq opencv-python numpy pytest
+
+# Download YOLO-World weights
+mkdir -p models && \
+wget -O models/yolo_world_s.pt \
+  https://huggingface.co/AILab-CVC/yolo-world/resolve/main/yolo_world_s.pt

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,0 @@
-litter sucks

--- a/src/arm_listener.py
+++ b/src/arm_listener.py
@@ -1,0 +1,68 @@
+"""ZeroMQ subscriber that commands the robotic arm via serial G-code."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Dict
+
+import serial  # type: ignore
+import zmq
+
+PUB_ADDRESS = "tcp://localhost:5557"
+SERIAL_PORT = "/dev/ttyUSB0"  # TODO: adjust for your hardware
+BAUD = 115200
+HOVER_Z = 50
+GRIP_Z = 5
+DUMP_X = 300
+DUMP_Y = 0
+DUMP_Z = 0
+
+
+def send_gcode(ser: serial.Serial, cmd: str) -> None:
+    ser.write(f"{cmd}\n".encode())
+    time.sleep(0.05)
+
+
+def goto(ser: serial.Serial, x: float, y: float, z: float) -> None:
+    send_gcode(ser, f"GOTO {x:.1f} {y:.1f} {z:.1f}")
+
+
+def grip_open(ser: serial.Serial) -> None:
+    send_gcode(ser, "GRIP OPEN")
+
+
+def grip_close(ser: serial.Serial) -> None:
+    send_gcode(ser, "GRIP CLOSE")
+
+
+def main() -> None:
+    context = zmq.Context.instance()
+    sock = context.socket(zmq.SUB)
+    try:
+        sock.connect(PUB_ADDRESS)
+        sock.setsockopt_string(zmq.SUBSCRIBE, "")
+    except zmq.ZMQError as exc:
+        print(f"ZeroMQ connect failed: {exc}")
+        return
+
+    ser = serial.Serial(SERIAL_PORT, BAUD, timeout=1)
+
+    while True:
+        msg = sock.recv_json()
+        if msg.get("conf", 0.0) < 0.15:
+            continue
+        x = msg["x_mm"]
+        y = msg["y_mm"]
+        theta = msg["theta"]
+        goto(ser, x, y, HOVER_Z)
+        goto(ser, x, y, GRIP_Z)
+        grip_close(ser)
+        goto(ser, x, y, HOVER_Z)
+        goto(ser, DUMP_X, DUMP_Y, HOVER_Z)
+        goto(ser, DUMP_X, DUMP_Y, DUMP_Z)
+        grip_open(ser)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/butt_detector.py
+++ b/src/butt_detector.py
@@ -1,0 +1,79 @@
+"""Vision producer that detects cigarette butts and publishes positions."""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import Any, Dict
+
+import cv2
+import numpy as np
+import zmq
+
+from ultralytics import YOLO
+
+from . import utils
+
+MODEL = "models/yolo_world_s.pt"
+PROMPTS = ["cigarette butt", "cigarette filter"]
+CONF_THRES = 0.25
+PUB_ADDRESS = "tcp://*:5557"
+
+
+def main() -> None:
+    """Run detection loop and publish over ZeroMQ."""
+    try:
+        detector = YOLO(MODEL)
+    except Exception as exc:
+        print(f"Failed to load model: {exc}")
+        sys.exit(1)
+
+    context = zmq.Context.instance()
+    sock = context.socket(zmq.PUB)
+    try:
+        sock.bind(PUB_ADDRESS)
+    except zmq.ZMQError as exc:
+        print(f"ZeroMQ bind failed: {exc}")
+        return
+
+    cap = cv2.VideoCapture(0)
+    if not cap.isOpened():
+        raise RuntimeError("Could not open camera")
+
+    imgsz = 640
+    while True:
+        t0 = time.time()
+        ret, frame = cap.read()
+        if not ret:
+            continue
+
+                results = detector.predict(frame, imgsz=imgsz, classes=PROMPTS, conf=CONF_THRES)
+        msg: Dict[str, Any] = {}
+        if results[0].boxes:
+            box = results[0].boxes[0]
+            x1, y1, x2, y2 = box.xyxy[0].cpu().numpy().tolist()
+            conf = float(box.conf[0])
+            cx = (x1 + x2) / 2
+            cy = (y1 + y2) / 2
+            w = x2 - x1
+            h = y2 - y1
+            x_mm, y_mm = utils.img_to_robot(cx, cy)
+            theta = utils.angle_from_bbox(w, h)
+            msg = {"x_mm": x_mm, "y_mm": y_mm, "theta": theta, "conf": conf}
+            sock.send_json(msg)
+        cv2.imshow("detector", annotated)
+        key = cv2.waitKey(1) & 0xFF
+        if key == 27:
+            break
+
+        fps = 1.0 / max(time.time() - t0, 1e-6)
+        if fps < 10 and imgsz != 320:
+            imgsz = 320
+            print("Performance low, switching to imgsz=320")
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fallback_blob.py
+++ b/src/fallback_blob.py
@@ -1,0 +1,65 @@
+"""HSV blob detector used when VLM confidence is low."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import cv2
+import numpy as np
+import zmq
+
+from . import utils
+
+PUB_ADDRESS = "tcp://*:5558"
+LOW_CONF = 0.1
+
+ORANGE_LOW = (5, 50, 50)
+ORANGE_HIGH = (20, 255, 255)
+WHITE_LOW = (0, 0, 200)
+WHITE_HIGH = (180, 60, 255)
+
+
+def main() -> None:
+    context = zmq.Context.instance()
+    sock = context.socket(zmq.PUB)
+    try:
+        sock.bind(PUB_ADDRESS)
+    except zmq.ZMQError as exc:
+        print(f"ZeroMQ bind failed: {exc}")
+        return
+
+    cap = cv2.VideoCapture(0)
+    if not cap.isOpened():
+        raise RuntimeError("Could not open camera")
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            continue
+        hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+        mask_o = cv2.inRange(hsv, ORANGE_LOW, ORANGE_HIGH)
+        mask_w = cv2.inRange(hsv, WHITE_LOW, WHITE_HIGH)
+        mask = cv2.bitwise_or(mask_o, mask_w)
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        for cnt in contours:
+            area = cv2.contourArea(cnt)
+            if area < 300:
+                continue
+            M = cv2.moments(cnt)
+            if M["m00"] == 0:
+                continue
+            cx = M["m10"] / M["m00"]
+            cy = M["m01"] / M["m00"]
+            x_mm, y_mm = utils.img_to_robot(cx, cy)
+            msg = {"x_mm": x_mm, "y_mm": y_mm, "theta": 0.0, "conf": LOW_CONF, "source": "blob"}
+            sock.send_json(msg)
+        cv2.imshow("blob", mask)
+        if cv2.waitKey(1) & 0xFF == 27:
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,41 @@
+"""Utility functions for coordinate transforms and angles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import cv2
+import numpy as np
+
+HOMOGRAPHY_PATH = Path("calib/homography.npy")
+
+
+def _load_homography() -> np.ndarray:
+    if not HOMOGRAPHY_PATH.exists():
+        raise FileNotFoundError(str(HOMOGRAPHY_PATH))
+    return np.load(str(HOMOGRAPHY_PATH))
+
+
+def img_to_robot(cx: float, cy: float) -> Tuple[float, float]:
+    """Convert pixel coordinates to millimetres using cached homography."""
+    H = _load_homography()
+    pt = np.array([[cx, cy, 1.0]], dtype=float).T
+    world = H @ pt
+    world /= world[2, 0]
+    return float(world[0, 0]), float(world[1, 0])
+
+
+def angle_from_bbox(w: float, h: float) -> float:
+    """Return object orientation in radians using bounding box."""
+    return float(np.pi/2) if h > w else 0.0
+
+
+def mask_principal_angle(mask: np.ndarray) -> float:
+    """Return principal axis angle of binary mask in radians."""
+    coords = cv2.findNonZero(mask)
+    if coords is None:
+        return 0.0
+    mean, eigvecs = cv2.PCACompute(coords.astype(np.float32), mean=None)[:2]
+    vec = eigvecs[0]
+    return float(np.arctan2(vec[1], vec[0]))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+"""Unit tests for utils helper functions."""
+
+import math
+from unittest import mock
+import sys, os
+os.chdir(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.getcwd())
+
+import numpy as np
+
+import src.utils as utils
+
+
+def test_img_to_robot_roundtrip() -> None:
+    H = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    with mock.patch("src.utils._load_homography", return_value=H):
+        x, y = utils.img_to_robot(0.0, 0.0)
+    assert abs(x) <= 1
+    assert abs(y) <= 1
+
+
+def test_angle_from_bbox() -> None:
+    angle = utils.angle_from_bbox(20, 80)
+    assert math.isclose(angle, math.pi / 2, abs_tol=0.05)


### PR DESCRIPTION
## Summary
- add environment setup script
- implement calibration helpers for homography
- add vision producer and arm subscriber modules
- provide fallback HSV blob detector
- define shared utility functions
- add basic unit tests
- write documentation with usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8f9d4bb0832ca018bbbb200b7ba6